### PR TITLE
Make UTC time selectable

### DIFF
--- a/googauth.go
+++ b/googauth.go
@@ -161,7 +161,7 @@ func (c *OTPConfig) Authenticate(password string) (bool, error) {
 	}
 
 	// assume we're on Time-basd OTP
-	t0 := int(time.Now().Unix() / 30)
+	t0 := int(time.Now().UTC().Unix() / 30)
 	return c.checkTotpCode(t0, code), nil
 }
 

--- a/googauth.go
+++ b/googauth.go
@@ -60,6 +60,7 @@ type OTPConfig struct {
 	HotpCounter   int    // the current otp counter.  0 if the user uses time-based codes instead.
 	DisallowReuse []int  // timestamps in the current window unavailable for re-use
 	ScratchCodes  []int  // an array of 8-digit numeric codes that can be used to log in
+	UTC           bool   // use UTC for the timestamp instead of local time
 }
 
 func (c *OTPConfig) checkScratchCodes(code int) bool {
@@ -160,8 +161,13 @@ func (c *OTPConfig) Authenticate(password string) (bool, error) {
 		return c.checkHotpCode(code), nil
 	}
 
-	// assume we're on Time-basd OTP
-	t0 := int(time.Now().UTC().Unix() / 30)
+	var t0 int
+	// assume we're on Time-based OTP
+	if c.UTC {
+		t0 = int(time.Now().UTC().Unix() / 30)
+	} else {
+		t0 = int(time.Now().Unix() / 30)
+	}
 	return c.checkTotpCode(t0, code), nil
 }
 

--- a/googauth_test.go
+++ b/googauth_test.go
@@ -192,7 +192,7 @@ func TestAuthenticate(t *testing.T) {
 	// let's check some time-based codes
 	otpconf.HotpCounter = 0
 	// I haven't mocked the clock, so we'll just compute one
-	t0 := int64(time.Now().Unix() / 30)
+	t0 := int64(time.Now().UTC().Unix() / 30)
 	c := ComputeCode(otpconf.Secret, t0)
 
 	invalid := c + 1

--- a/googauth_test.go
+++ b/googauth_test.go
@@ -192,7 +192,12 @@ func TestAuthenticate(t *testing.T) {
 	// let's check some time-based codes
 	otpconf.HotpCounter = 0
 	// I haven't mocked the clock, so we'll just compute one
-	t0 := int64(time.Now().UTC().Unix() / 30)
+	var t0 int64
+	if otpconf.UTC {
+		t0 = int64(time.Now().UTC().Unix() / 30)
+	} else {
+		t0 = int64(time.Now().Unix() / 30)
+	}
 	c := ComputeCode(otpconf.Secret, t0)
 
 	invalid := c + 1
@@ -206,6 +211,13 @@ func TestAuthenticate(t *testing.T) {
 		if r != a.result {
 			t.Errorf("bad result from code=%s: got %t expected %t\n", a.code, r, a.result)
 		}
+
+		otpconf.UTC = true
+		r, _ = otpconf.Authenticate(a.code)
+		if r != a.result {
+			t.Errorf("bad result from code=%s: got %t expected %t\n", a.code, r, a.result)
+		}
+		otpconf.UTC = false
 	}
 
 }


### PR DESCRIPTION
For compatibility reasons, the library will need to use local time.
However, switching on UTC is available via a boolean field in the
configuration structure. This extends #3, which switches completely
to UTC, by adding this field.
