### PR TITLE
Updated link to conflicting accounts

### DIFF
--- a/googauth.go
+++ b/googauth.go
@@ -181,7 +181,7 @@ func (c *OTPConfig) ProvisionURI(user string) string {
 // to configure a Google Authenticator mobile app. It respects the recommendations
 // on how to avoid conflicting accounts.
 //
-// See https://code.google.com/p/google-authenticator/wiki/ConflictingAccounts
+// See https://github.com/google/google-authenticator/wiki/Conflicting-Accounts
 func (c *OTPConfig) ProvisionURIWithIssuer(user string, issuer string) string {
 	auth := "totp/"
 	q := make(url.Values)


### PR DESCRIPTION
google code isn't there any more, and the automatic redirect from google code to github takes you to the root of the project.